### PR TITLE
Solo Hunt Reroll Feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies {
 
 	modCompileOnly(files("libs/everlastingutils-1.0.8.jar"))
 
+	modCompileOnly "net.impactdev.impactor:common:5.3.0+1.21.1"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.16.10
 fabric_kotlin_version=1.13.2+kotlin.2.1.20
 
 # Mod Properties
-mod_version=1.0.6
+mod_version=1.0.7
 maven_group=com.cobblehunts
 archives_base_name=cobblehunts
 

--- a/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
+++ b/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
@@ -62,8 +62,6 @@ object HuntsSoloGui {
 
         val economyEnabled = config.economyEnabled
         val rerollSlots = slots.map { it + 9 }
-        // (Special case: only 3 hunt difficulties active)
-        // If reroll slot collides with back slot, move back button to the end
         val backSlot = if (SoloSlots.BACK in rerollSlots) 26 else SoloSlots.BACK
 
         for ((index, difficulty) in enabledDifficulties.withIndex()) {
@@ -144,8 +142,6 @@ object HuntsSoloGui {
         val perms = HuntsConfig.config.permissions
         val source = player.server.commandSource.withEntity(player).withPosition(player.pos)
         val rerollSlots = slots.map { it + 9 }
-        // (Special case: only 3 hunt difficulties active)
-        // If reroll slot collides with back slot, move back button to the end
         val backSlot = if (SoloSlots.BACK in rerollSlots) 26 else SoloSlots.BACK
 
         for ((index, difficulty) in enabledDifficulties.withIndex()) {

--- a/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
+++ b/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
@@ -3,7 +3,11 @@ package com.cobblehunts.gui.huntsgui
 import com.cobblehunts.CobbleHunts
 import com.cobblehunts.gui.HuntsGui
 import com.cobblehunts.gui.TurnInGui
+import com.cobblehunts.utils.EconomyAdapter
 import com.cobblehunts.utils.HuntsConfig
+import com.cobblehunts.utils.RerollService
+import com.cobblehunts.utils.rerollRules
+import com.everlastingutils.command.CommandManager
 import com.everlastingutils.gui.CustomGui
 import com.everlastingutils.gui.InteractionContext
 import com.everlastingutils.gui.setCustomName
@@ -22,6 +26,7 @@ object HuntsSoloGui {
 
     private object SoloTextures {
         const val BACK = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzI0MzE5MTFmNDE3OGI0ZDJiNDEzYWE3ZjVjNzhhZTQ0NDdmZTkyNDY5NDNjMzFkZjMxMTYzYzBlMDQzZTBkNiJ9fX0="
+        const val REROLL = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWIzOTE0NTc2YjBiOGU4NzQ5ZTE1ZmJmZWUwNWExNmVhNDEzZDBkNTg1M2M5MDM0MjA5NGViNmFmODI5ZjlmZiJ9fX0="
     }
 
     private val soloHuntSlotMap = mapOf(
@@ -52,9 +57,20 @@ object HuntsSoloGui {
         val count = enabledDifficulties.size
         val slots = soloHuntSlotMap[count] ?: listOf()
 
+        val config = HuntsConfig.config
+        val data = CobbleHunts.getPlayerData(player)
+
+        val economyEnabled = config.economyEnabled
+        val rerollSlots = slots.map { it + 9 }
+        // (Special case: only 3 hunt difficulties active)
+        // If reroll slot collides with back slot, move back button to the end
+        val backSlot = if (SoloSlots.BACK in rerollSlots) 26 else SoloSlots.BACK
+
         for ((index, difficulty) in enabledDifficulties.withIndex()) {
             val indicatorSlot = slots[index] - 9
-            val data = CobbleHunts.getPlayerData(player)
+            val previewSlot = slots[index]
+            val rerollSlot = previewSlot + 9
+
             val activeInstance = data.activePokemon[difficulty]
             val isActive = activeInstance != null && (activeInstance.endTime == null || System.currentTimeMillis() < activeInstance.endTime!!)
             layout[indicatorSlot] = if (isActive) {
@@ -63,9 +79,34 @@ object HuntsSoloGui {
                 ItemStack(Items.BLACK_STAINED_GLASS_PANE).apply { setCustomName(Text.literal("")) }
             }
             layout[slots[index]] = HuntsGuiUtils.getSoloDynamicItem(player, difficulty)
+
+            val rules = data.rerollRules(difficulty)
+
+            val lore = mutableListOf<Text>().apply {
+                if (economyEnabled) {
+                    add(Text.literal("Cost: ${EconomyAdapter.symbol()}${rules.cost} ${EconomyAdapter.currencyId()}")
+                        .setStyle(Style.EMPTY.withItalic(false))
+                        .styled { it.withColor(Formatting.GRAY) }
+                    )
+                }
+                add (
+                    Text.literal("Rerolls: ${if (rules.unlimited) "Unlimited" else "${rules.used}/${rules.limit}"}")
+                        .setStyle(Style.EMPTY.withItalic(false))
+                        .styled { it.withColor(if (rules.unlimited || rules.used < rules.limit) Formatting.YELLOW else Formatting.RED) }
+                )
+            }
+
+            layout[rerollSlot] = CustomGui.createPlayerHeadButton(
+                textureName = "Reroll $difficulty",
+                title = Text.literal("Reroll (${difficulty.replaceFirstChar { it.uppercaseChar() }})")
+                    .setStyle(Style.EMPTY.withItalic(false))
+                    .styled { it.withColor(Formatting.GREEN) },
+                lore = lore,
+                textureValue = SoloTextures.REROLL
+            )
         }
 
-        layout[SoloSlots.BACK] = CustomGui.createPlayerHeadButton(
+        layout[backSlot] = CustomGui.createPlayerHeadButton(
             textureName = "Back",
             title = Text.literal("Back").setStyle(Style.EMPTY.withItalic(false)).styled { it.withColor(Formatting.YELLOW) },
             lore = listOf(Text.literal("Return to main menu").setStyle(Style.EMPTY.withItalic(false)).styled { it.withColor(Formatting.GRAY) }),
@@ -78,10 +119,12 @@ object HuntsSoloGui {
         val enabledDifficulties = getEnabledSoloDifficulties()
         val count = enabledDifficulties.size
         val slots = soloHuntSlotMap[count] ?: listOf()
+        val data = CobbleHunts.getPlayerData(player)
+        data.resetRerollsIfNeeded()
 
         for ((index, difficulty) in enabledDifficulties.withIndex()) {
             val indicatorSlot = slots[index] - 9
-            val data = CobbleHunts.getPlayerData(player)
+
             val activeInstance = data.activePokemon[difficulty]
             val isActive = activeInstance != null && (activeInstance.endTime == null || System.currentTimeMillis() < activeInstance.endTime!!)
             layout[indicatorSlot] = if (isActive) {
@@ -97,6 +140,30 @@ object HuntsSoloGui {
         val enabledDifficulties = getEnabledSoloDifficulties()
         val count = enabledDifficulties.size
         val slots = soloHuntSlotMap[count] ?: listOf()
+
+        val perms = HuntsConfig.config.permissions
+        val source = player.server.commandSource.withEntity(player).withPosition(player.pos)
+        val rerollSlots = slots.map { it + 9 }
+        // (Special case: only 3 hunt difficulties active)
+        // If reroll slot collides with back slot, move back button to the end
+        val backSlot = if (SoloSlots.BACK in rerollSlots) 26 else SoloSlots.BACK
+
+        for ((index, difficulty) in enabledDifficulties.withIndex()) {
+            val rerollSlot = slots[index] + 9
+            if (context.slotIndex == rerollSlot) {
+                if (!CommandManager.hasPermissionOrOp(source,perms.rerollPermission,perms.permissionLevel, perms.opLevel)) {
+                    player.sendMessage(Text.literal("You do not have permission to reroll hunts.").styled { it.withColor(Formatting.RED) }, false)
+                    return
+                }
+
+                if (RerollService.tryRerollPreview(player, difficulty)) {
+                    val newLayout = generateSoloLayout(player).toMutableList()
+                    HuntsGui.dynamicGuiData[player] = Pair("solo", newLayout)
+                    CustomGui.refreshGui(player, newLayout)
+                }
+                return
+            }
+        }
 
         if (context.slotIndex in slots) {
             val index = slots.indexOf(context.slotIndex)
@@ -142,7 +209,7 @@ object HuntsSoloGui {
             } else {
                 TurnInGui.openTurnInGui(player, difficulty)
             }
-        } else if (context.slotIndex == SoloSlots.BACK) {
+        } else if (context.slotIndex == backSlot) {
             HuntsGui.openMainGui(player)
         }
     }

--- a/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
+++ b/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
@@ -152,6 +152,16 @@ object HuntsSoloGui {
                     return
                 }
 
+                if (CobbleHunts.isOnCooldown(player, difficulty)) {
+                    player.sendMessage(
+                        Text.literal("You are on cooldown for $difficulty missions!")
+                            .setStyle(Style.EMPTY.withItalic(false))
+                            .styled { it.withColor(Formatting.RED) },
+                        false
+                    )
+                    return
+                }
+
                 if (RerollService.tryRerollPreview(player, "solo$difficulty")) {
                     val newLayout = generateSoloLayout(player).toMutableList()
                     HuntsGui.dynamicGuiData[player] = Pair("solo", newLayout)

--- a/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
+++ b/src/main/kotlin/com/cobblehunts/gui/huntsgui/HuntsSoloGui.kt
@@ -156,7 +156,7 @@ object HuntsSoloGui {
                     return
                 }
 
-                if (RerollService.tryRerollPreview(player, difficulty)) {
+                if (RerollService.tryRerollPreview(player, "solo$difficulty")) {
                     val newLayout = generateSoloLayout(player).toMutableList()
                     HuntsGui.dynamicGuiData[player] = Pair("solo", newLayout)
                     CustomGui.refreshGui(player, newLayout)

--- a/src/main/kotlin/com/cobblehunts/utils/EconomyAdapter.kt
+++ b/src/main/kotlin/com/cobblehunts/utils/EconomyAdapter.kt
@@ -1,0 +1,50 @@
+package com.cobblehunts.utils
+
+import com.cobblehunts.CobbleHunts
+import net.impactdev.impactor.api.economy.EconomyService
+import net.impactdev.impactor.api.economy.currency.Currency
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import net.minecraft.server.network.ServerPlayerEntity
+import java.math.BigDecimal
+
+object EconomyAdapter {
+    private val service by lazy { EconomyService.instance() }
+    private val warnedInvalidCurrency = mutableSetOf<String>()
+
+    /** Find the configured Currency or fallback to primary. */
+    fun currency(): Currency {
+        val config = HuntsConfig.config
+        val id = config.rerollCurrency.ifBlank { return service.currencies().primary() }
+        val key = Key.key(if (id.contains(':')) id else "impactor:$id")
+
+        val currencyOpt = service.currencies().currency(key)
+        if (currencyOpt.isPresent) {
+            return currencyOpt.get()
+        }
+
+        // Avoid repeated warning calls.
+        if (warnedInvalidCurrency.add(id)) {
+            CobbleHunts.logger.warn("[CobbleHunts] Currency '$id' not found, defaulting to primary.")
+        }
+        return service.currencies().primary()
+    }
+
+    /** Key string for chat messages. */
+    fun currencyId(): String =
+        currency().key().value()
+
+    /** Symbol (e.g., "$") for chat messages. */
+    fun symbol(): String =
+        PlainTextComponentSerializer.plainText().serialize(currency().symbol())
+
+    /**
+     * Attempts withdrawal.
+     * Returns true if economy is disabled or withdraw succeeds.
+     */
+    fun charge(player: ServerPlayerEntity, amount: BigDecimal): Boolean {
+        if (!HuntsConfig.config.economyEnabled) return true
+        val account = service.account(currency(), player.uuid).join()
+        return account.withdraw(amount).successful()
+    }
+}

--- a/src/main/kotlin/com/cobblehunts/utils/HuntsCommands.kt
+++ b/src/main/kotlin/com/cobblehunts/utils/HuntsCommands.kt
@@ -1,5 +1,6 @@
-package com.cobblehunts
+package com.cobblehunts.utils
 
+import com.cobblehunts.CobbleHunts
 import com.everlastingutils.command.CommandManager
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
@@ -8,11 +9,8 @@ import com.mojang.brigadier.context.CommandContext
 import net.minecraft.server.command.ServerCommandSource
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
-import com.cobblehunts.utils.HuntsConfig
 import com.cobblehunts.gui.HuntsGui
 import com.cobblehunts.gui.huntseditorgui.HuntsEditorMainGui
-import com.cobblehunts.utils.CatchingTracker
-import com.cobblehunts.utils.RerollService
 
 import com.cobblemon.mod.common.Cobblemon
 import net.fabricmc.loader.api.FabricLoader

--- a/src/main/kotlin/com/cobblehunts/utils/HuntsCommands.kt
+++ b/src/main/kotlin/com/cobblehunts/utils/HuntsCommands.kt
@@ -363,7 +363,7 @@ object HuntsCommands {
             return 0
         }
 
-        val success = RerollService.tryRerollPreview(target, huntType)
+        val success = RerollService.tryRerollPreview(target, huntType, true)
         if (source.player !is ServerPlayerEntity || source.player != target) {
             if (success) {
                 source.sendMessage(

--- a/src/main/kotlin/com/cobblehunts/utils/HuntsConfig.kt
+++ b/src/main/kotlin/com/cobblehunts/utils/HuntsConfig.kt
@@ -106,7 +106,7 @@ data class HuntPermissions(
  * The non-pool settings are at the top, while all the spawn/loot pools are at the bottom.
  */
 data class HuntsConfigData(
-    override val version: String = "1.0.6",
+    override val version: String = "1.0.7",
     override val configId: String = "cobblehunts",
     var debugEnabled: Boolean = false,
     var activeGlobalHuntsAtOnce: Int = 4,
@@ -321,7 +321,7 @@ object HuntsConfig {
         )
     }
     private val configManager = ConfigManager(
-        currentVersion = "1.0.6",
+        currentVersion = "1.0.7",
         defaultConfig = createDefaultConfig(),
         configClass = HuntsConfigData::class,
         metadata = ConfigMetadata(

--- a/src/main/kotlin/com/cobblehunts/utils/HuntsConfig.kt
+++ b/src/main/kotlin/com/cobblehunts/utils/HuntsConfig.kt
@@ -11,12 +11,10 @@ import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import com.mojang.serialization.DynamicOps
 import kotlinx.coroutines.runBlocking
-import net.minecraft.component.DataComponentTypes
 import net.minecraft.item.ItemStack
-import net.minecraft.registry.RegistryOps
-import net.minecraft.text.Text
 import net.minecraft.util.JsonHelper
 import java.lang.RuntimeException
+import java.math.BigDecimal
 
 /**
  * Data class representing a Pokémon entry in a hunt.
@@ -96,7 +94,10 @@ data class HuntPermissions(
     var soloEasyHuntPermission: String = "cobblehunts.solo.easy",
     var soloNormalHuntPermission: String = "cobblehunts.solo.normal",
     var soloMediumHuntPermission: String = "cobblehunts.solo.medium",
-    var soloHardHuntPermission: String = "cobblehunts.solo.hard"
+    var soloHardHuntPermission: String = "cobblehunts.solo.hard",
+    var rerollPermission: String = "cobblehunts.solo.reroll.use",
+    var bypassRerollLimitPermission: String = "cobblehunts.solo.reroll.bypass.limit",
+    var bypassRerollCostPermission: String = "cobblehunts.solo.reroll.bypass.cost"
 )
 
 /**
@@ -150,7 +151,23 @@ data class HuntsConfigData(
     var soloEasyLoot: MutableList<LootReward> = mutableListOf(),
     var soloNormalLoot: MutableList<LootReward> = mutableListOf(),
     var soloMediumLoot: MutableList<LootReward> = mutableListOf(),
-    var soloHardLoot: MutableList<LootReward> = mutableListOf()
+    var soloHardLoot: MutableList<LootReward> = mutableListOf(),
+    var economyEnabled: Boolean = true,
+    var rerollCurrency: String = "pokedollars",
+    var rerollCost: Map<String, BigDecimal> = mapOf(
+        "easy" to BigDecimal("100.00"),
+        "normal" to BigDecimal("200.00"),
+        "medium" to BigDecimal("300.00"),
+        "hard" to BigDecimal("400.00")
+    ),
+    var universalRerollLimit: Int = -1,
+    var maxRerollsPerDay: Map<String, Int> = mapOf(
+        "easy" to 3,
+        "normal" to 3,
+        "medium" to 3,
+        "hard" to 3
+    ),
+    var allowRerollDuplicates: Boolean = true
 ) : ConfigData
 
 object HuntsConfig {
@@ -348,7 +365,8 @@ object HuntsConfig {
     val config: HuntsConfigData get() = configManager.getCurrentConfig()
 
     /** Initializes and loads the config. */
-    fun initializeAndLoad() { runBlocking { configManager.reloadConfig() } }
+    fun initializeAndLoad() { runBlocking { configManager.reloadConfig() }
+                              saveConfig()  }
 
     /** Saves the current config. */
     fun saveConfig() { runBlocking { configManager.saveConfig(config) } }

--- a/src/main/kotlin/com/cobblehunts/utils/RerollService.kt
+++ b/src/main/kotlin/com/cobblehunts/utils/RerollService.kt
@@ -1,0 +1,110 @@
+package com.cobblehunts.utils
+
+import com.cobblehunts.CobbleHunts
+import com.cobblehunts.PlayerHuntData
+import com.everlastingutils.command.CommandManager
+import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.text.Text
+import net.minecraft.util.Formatting
+import java.math.BigDecimal
+
+object RerollService {
+    fun tryRerollPreview(player: ServerPlayerEntity, huntType: String): Boolean {
+        val config = HuntsConfig.config
+        val perms = config.permissions
+        val source = player.server.commandSource.withEntity(player).withPosition(player.pos)
+
+        if (!CommandManager.hasPermissionOrOp(source, perms.rerollPermission, perms.permissionLevel, perms.opLevel)) {
+            player.sendMessage(Text.literal("You do not have permission to reroll hunts")
+                .styled { it.withColor(Formatting.RED) }, false)
+            return false
+        }
+
+        val difficulty = when (huntType) {
+            "soloeasy" -> "easy"
+            "solonormal" -> "normal"
+            "solomedium" -> "medium"
+            "solohard" -> "hard"
+            else -> {
+                player.sendMessage(Text.literal("Invalid hunt type: $huntType"), false)
+                return false
+            }
+        }
+
+        val data = CobbleHunts.getPlayerData(player)
+        val rules = data.rerollRules(difficulty)
+
+        val canBypassLimit = CommandManager.hasPermissionOrOp(source, perms.bypassRerollLimitPermission, perms.permissionLevel, perms.opLevel)
+        val canBypassCost = CommandManager.hasPermissionOrOp(source, perms.bypassRerollCostPermission, perms.permissionLevel, perms.opLevel)
+
+        if (!canBypassLimit && !rules.unlimited && rules.used >= rules.limit) {
+            player.sendMessage(Text.literal("You have used all ${rules.limit} rerolls today for $difficulty mission.")
+                .styled { it.withColor(Formatting.RED) }, false)
+            return false
+        }
+
+        if (config.economyEnabled && !canBypassCost) {
+            if (!EconomyAdapter.charge(player, rules.cost)) {
+                player.sendMessage(Text.literal("You need ${EconomyAdapter.symbol()}${rules.cost} ${EconomyAdapter.currencyId()} to reroll.")
+                    .styled { it.withColor(Formatting.RED) }, false)
+                return false
+            }
+        }
+
+        data.activePokemon.remove(difficulty)
+
+        val previous = data.previewPokemon[difficulty]?.entry?.species
+        val entry = CobbleHunts.selectPokemonForDifficulty(difficulty)?.let { first ->
+            if (config.allowRerollDuplicates || previous == null) first
+            else run {
+                repeat(5) {
+                    val candidate = CobbleHunts.selectPokemonForDifficulty(difficulty) ?: return@repeat
+                    if (!candidate.species.equals(previous, ignoreCase = true)) return@run candidate
+                }
+                first
+            }
+        } ?: run {
+            player.sendMessage(
+                Text.literal("No $difficulty hunt available right now.")
+                    .styled { it.withColor(Formatting.RED) }, false)
+            return false
+        }
+
+        val preview = CobbleHunts.createHuntInstance(entry, difficulty)
+        data.previewPokemon[difficulty] = preview
+
+        if (!canBypassLimit && !rules.unlimited) {
+            if (config.universalRerollLimit >= 0) data.globalRerollsToday = rules.used + 1
+            else data.rerollsToday[difficulty] = rules.used + 1
+        }
+
+        val speciesLabel = entry.species.replaceFirstChar { it.uppercaseChar() }
+        player.sendMessage(
+            Text.literal("Rerolled $difficulty mission to $speciesLabel.")
+            .styled { it.withColor(Formatting.GREEN) }, false)
+        return true
+    }
+}
+
+/** Holds all reroll repeated data for a given difficulty. */
+data class RerollRules(
+    val cost: BigDecimal,
+    val limit: Int,
+    val used: Int,
+    val unlimited: Boolean
+)
+
+/**
+ * Extension to [PlayerHuntData] so that all code can call the same logic without duplicate code.
+ */
+fun PlayerHuntData.rerollRules(difficulty: String, config: HuntsConfigData = HuntsConfig.config): RerollRules {
+    resetRerollsIfNeeded()
+    val cost = config.rerollCost[difficulty] ?: BigDecimal.ZERO
+    val perLimit = config.maxRerollsPerDay[difficulty] ?: 0
+    val universal = config.universalRerollLimit
+    val limit = if (universal >= 0) universal else perLimit
+    val used = if (universal >= 0) globalRerollsToday else rerollsToday.getOrDefault(difficulty, 0)
+
+    val unlimited = (limit == 0)
+    return RerollRules(cost, limit, used, unlimited)
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -48,6 +48,7 @@
 		"fabric-language-kotlin": "*"
 	},
 	"suggests": {
-		"another-mod": "*"
+		"another-mod": "*",
+		"impactor": ">5.3.0+1.21.1"
 	}
 }


### PR DESCRIPTION
# Solo Hunt Reroll Feature

## Overview

This PR introduces a highly requested reroll system for solo hunts, with integrated economy support (Impactor) and a fallback when Impactor is not installed.

## Changes

- **RerollService**
  - Centralises all reroll logic into one place.
- **RerollRules**
  - New data class with `PlayerHuntData.rerollRules()` extension to encapsulate `cost`, `limit`, `used` and `unlimited` data.
- **EconomyAdapter**
  - Wraps Impactor's `EconomyService`.
  - Falls back to 'free' mode if Impactor is missing (logged once at startup).
- **Commands**
  - `/hunts reroll <huntType> [player]` (intended for Admins only)  
    - With no `[player]`, this will reroll the executor's hunt (ignoring cost and limit)
    - With `[player]`, this will reroll the target player's hunt (ignoring cost and limit)
- **Permissions**
  - `cobblehunts.reroll` - [Admins] Allows user to reroll their own and other player's hunts whilst bypassing cost and limit.
  - `cobblehunts.solo.reroll.use` - Allows user to reroll hunts only within the GUI menu, whilst respecting cost and limit set in the configuration.
  - `cobblehunts.solo.reroll.bypass.limit`. - Allows user to bypass the reroll limit for each difficulty listed in the configuration.
  - `cobblehunts.solo.reroll.bypass.cost`. - Allows user to bypass the cost of reroll for each difficulty listed in the configuration.
- **Button Overlap**
  - Detects when slot 22 would overlap a reroll button and moves the back button to slot 26 in that case.
    - This is the case when only 1 or 3 hunt difficulties are active.

## Potential Updates

- Support for additional economy providers beyond Impactor.
